### PR TITLE
Update docker-compose.yml to assign Redis service to 'redis' profile for improved service management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,6 @@ services:
             options:
                 max-size: "10m"
                 max-file: "3"
-        depends_on:
-            alphaedge__redis:
-                condition: service_healthy
         env_file:
             - ./.env
         ports:
@@ -48,6 +45,7 @@ services:
                     memory: 128M # Reserve 128 MB memory
 
     alphaedge__redis:
+        profiles: ["redis-service"]
         image: redis:latest
         container_name: alphaedge__redis
         command: redis-server --requirepass ${REDIS_PASSWORD}


### PR DESCRIPTION
- docker doesnt try to create redis container when deploy.sh is run